### PR TITLE
Develop - 0.11.5

### DIFF
--- a/Assets/Editor Toolbox/CHANGELOG.md
+++ b/Assets/Editor Toolbox/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.11.5 [18.08.2022]
+
+### Added:
+- Possibility to hide the m_Script property while using the InLineEditorAttribute (HideScript = true)
+- Possibility to pick base type in the ReferencePickerAttribute
+- Possibility to pick display options in the ReferencePickerAttribute
+
+### Changed:
+- Fix displaying custom labels in the ToolboxEditorList
+- For now all methods placed in the PropertyUtility script are public
+
 ## 0.11.4 [17.07.2022]
 
 ### Added:

--- a/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/InLineEditorAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/InLineEditorAttributeDrawer.cs
@@ -23,6 +23,14 @@ namespace Toolbox.Editor.Drawers
                             editor.ReloadPreviewInstances();
                         }
 
+                        if (a.HideScript)
+                        {
+                            if (editor is ToolboxEditor toolboxEditor)
+                            {
+                                toolboxEditor.IgnoreProperty(PropertyUtility.Defaults.scriptPropertyName);
+                            }
+                        }
+
                         return editor;
                     }
                     else

--- a/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
@@ -10,8 +10,15 @@ namespace Toolbox.Editor.Drawers
 
     public class ReferencePickerAttributeDrawer : ToolboxSelfPropertyDrawer<ReferencePickerAttribute>
     {
-        private readonly TypeField typeField = new TypeField(new TypeConstraintReference(null));
+        private static readonly TypeConstraintContext sharedConstraint = new TypeConstraintReference(null);
+        private static readonly TypeAppearanceContext sharedAppearance = new TypeAppearanceContext(sharedConstraint, TypeGrouping.None, true);
+        private static readonly TypeField typeField = new TypeField(sharedConstraint, sharedAppearance);
 
+
+        private void UpdateContexts(ReferencePickerAttribute attribute)
+        {
+            sharedAppearance.TypeGrouping = attribute.TypeGrouping;
+        }
 
         private void CreateTypeProperty(SerializedProperty property, Type parentType)
         {
@@ -72,7 +79,6 @@ namespace Toolbox.Editor.Drawers
             return propertyType;
         }
 
-
         protected override void OnGuiSafe(SerializedProperty property, GUIContent label, ReferencePickerAttribute attribute)
         {
             using (var propertyScope = new PropertyScope(property, label))
@@ -82,8 +88,10 @@ namespace Toolbox.Editor.Drawers
                     return;
                 }
 
-                EditorGUI.indentLevel++;
+                UpdateContexts(attribute);
                 var parentType = GetParentType(property, attribute);
+
+                EditorGUI.indentLevel++;
                 CreateTypeProperty(property, parentType);
                 ToolboxEditorGui.DrawPropertyChildren(property);
                 EditorGUI.indentLevel--;

--- a/Assets/Editor Toolbox/Editor/Internal/ToolboxEditorList.cs
+++ b/Assets/Editor Toolbox/Editor/Internal/ToolboxEditorList.cs
@@ -82,7 +82,7 @@ namespace Toolbox.Editor.Internal
                     var elementRect = elementGroup.rect;
                     //adjust label width to the known dragging area
                     EditorGUIUtility.labelWidth -= Style.dragAreaWidth;
-                    DrawElement(index);
+                    DrawElement(elementRect, index, isActive, hasFocus);
                     EditorGUIUtility.labelWidth += Style.dragAreaWidth;
                 }
 
@@ -125,11 +125,18 @@ namespace Toolbox.Editor.Internal
             }
         }
 
-        private void DrawElement(int index)
+        private void DrawElement(Rect rect, int index, bool isActive, bool hasFocus)
         {
-            var element = List.GetArrayElementAtIndex(index);
-            var content = GetElementContent(element, index);
-            ToolboxEditorGui.DrawToolboxProperty(element, content);
+            if (drawElementCallback != null)
+            {
+                drawElementCallback(rect, index, isActive, hasFocus);
+            }
+            else
+            {
+                var element = List.GetArrayElementAtIndex(index);
+                var content = GetElementContent(element, index);
+                ToolboxEditorGui.DrawToolboxProperty(element, content);
+            }
         }
 
         /// <summary>

--- a/Assets/Editor Toolbox/Editor/Internal/TypesEditorCollection.cs
+++ b/Assets/Editor Toolbox/Editor/Internal/TypesEditorCollection.cs
@@ -79,6 +79,9 @@ namespace Toolbox.Editor.Internal
                     }
 
                     return "Scripts/" + type.FullName.Replace('.', '/');
+
+                case TypeGrouping.ByFlatName:
+                    return type.Name;
             }
         }
 

--- a/Assets/Editor Toolbox/Editor/Utilities/PropertyUtility.cs
+++ b/Assets/Editor Toolbox/Editor/Utilities/PropertyUtility.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 using UnityEditor;
 using Object = UnityEngine.Object;
@@ -14,7 +13,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Indicates if the property has all changes applied and can be safely used for reflection-based features.
         /// </summary>
-        internal static bool HasModifedProperties(this SerializedProperty property)
+        public static bool HasModifedProperties(this SerializedProperty property)
         {
             return property.serializedObject.hasModifiedProperties;
         }
@@ -22,7 +21,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Creates and returns unique (hash based) key for this property.
         /// </summary>
-        internal static string GetPropertyHashKey(this SerializedProperty property)
+        public static string GetPropertyHashKey(this SerializedProperty property)
         {
             var hash = property.serializedObject.GetHashCode();
 #if UNITY_2019_2_OR_NEWER
@@ -37,7 +36,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Creates and returns unique (type based) key for this property.
         /// </summary>
-        internal static string GetPropertyTypeKey(this SerializedProperty property)
+        public static string GetPropertyTypeKey(this SerializedProperty property)
         {
             var type = property.serializedObject.targetObject.GetType();
 #if UNITY_2019_2_OR_NEWER
@@ -52,7 +51,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Returns <see cref="object"/> which truly declares this property.
         /// </summary>
-        internal static object GetDeclaringObject(this SerializedProperty property)
+        public static object GetDeclaringObject(this SerializedProperty property)
         {
             return GetDeclaringObject(property, property.serializedObject.targetObject);
         }
@@ -60,7 +59,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Returns <see cref="object"/> which truly declares this property.
         /// </summary>
-        internal static object GetDeclaringObject(this SerializedProperty property, bool ignoreArrays)
+        public static object GetDeclaringObject(this SerializedProperty property, bool ignoreArrays)
         {
             return GetDeclaringObject(property, property.serializedObject.targetObject, ignoreArrays);
         }
@@ -68,7 +67,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Returns <see cref="object"/> which truly declares this property.
         /// </summary>
-        internal static object GetDeclaringObject(this SerializedProperty property, Object target)
+        public static object GetDeclaringObject(this SerializedProperty property, Object target)
         {
             return GetDeclaringObject(property, target, true);
         }
@@ -76,7 +75,7 @@ namespace Toolbox.Editor
         /// <summary>
         /// Returns <see cref="object"/> which truly declares this property.
         /// </summary>
-        internal static object GetDeclaringObject(this SerializedProperty property, Object target, bool ignoreArrays)
+        public static object GetDeclaringObject(this SerializedProperty property, Object target, bool ignoreArrays)
         {
             EnsureReflectionSafeness(property);
 
@@ -101,7 +100,7 @@ namespace Toolbox.Editor
             return validReference;
         }
 
-        internal static object GetTreePathReference(string treeField, object treeParent)
+        public static object GetTreePathReference(string treeField, object treeParent)
         {
             if (IsSerializableArrayElement(treeField, out var index))
             {
@@ -123,7 +122,7 @@ namespace Toolbox.Editor
         /// Returns proper <see cref="FieldInfo"/> value for this property, even if the property is an array element.
         /// </summary>
         /// <param name="fieldInfo">FieldInfo associated to provided property.</param>
-        internal static object GetProperValue(this SerializedProperty property, FieldInfo fieldInfo)
+        public static object GetProperValue(this SerializedProperty property, FieldInfo fieldInfo)
         {
             return GetProperValue(property, fieldInfo, property.GetDeclaringObject());
         }
@@ -133,7 +132,7 @@ namespace Toolbox.Editor
         /// </summary>
         /// <param name="property"></param>
         /// <param name="fieldInfo">FieldInfo associated to provided property.</param>
-        internal static object GetProperValue(this SerializedProperty property, FieldInfo fieldInfo, object declaringObject)
+        public static object GetProperValue(this SerializedProperty property, FieldInfo fieldInfo, object declaringObject)
         {
             if (fieldInfo == null)
             {
@@ -161,7 +160,7 @@ namespace Toolbox.Editor
         /// </summary>
         /// <param name="property"></param>
         /// <param name="fieldInfo">FieldInfo associated to provided property.</param>
-        internal static void SetProperValue(this SerializedProperty property, FieldInfo fieldInfo, object value)
+        public static void SetProperValue(this SerializedProperty property, FieldInfo fieldInfo, object value)
         {
             SetProperValue(property, fieldInfo, value, true);
         }
@@ -173,7 +172,7 @@ namespace Toolbox.Editor
         /// </summary>
         /// <param name="property"></param>
         /// <param name="fieldInfo">FieldInfo associated to provided property.</param>
-        internal static void SetProperValue(this SerializedProperty property, FieldInfo fieldInfo, object value, bool callOnValidate)
+        public static void SetProperValue(this SerializedProperty property, FieldInfo fieldInfo, object value, bool callOnValidate)
         {
             if (fieldInfo == null)
             {
@@ -211,7 +210,7 @@ namespace Toolbox.Editor
         /// Returns proper <see cref="Type"/> for this property, even if the property is an array element.
         /// </summary>
         /// <param name="fieldInfo">FieldInfo associated to provided property.</param>
-        internal static Type GetProperType(this SerializedProperty property, FieldInfo fieldInfo)
+        public static Type GetProperType(this SerializedProperty property, FieldInfo fieldInfo)
         {
             if (fieldInfo == null)
             {
@@ -233,7 +232,7 @@ namespace Toolbox.Editor
             }
         }
 
-        internal static Type GetScriptTypeFromProperty(SerializedProperty property)
+        public static Type GetScriptTypeFromProperty(SerializedProperty property)
         {
             var scriptProperty = property.serializedObject.FindProperty(Defaults.scriptPropertyName);
             if (scriptProperty == null)
@@ -251,17 +250,17 @@ namespace Toolbox.Editor
         }
 
 
-        internal static FieldInfo GetFieldInfo(this SerializedProperty property)
+        public static FieldInfo GetFieldInfo(this SerializedProperty property)
         {
             return GetFieldInfo(property, out _);
         }
 
-        internal static FieldInfo GetFieldInfo(this SerializedProperty property, out Type propertyType)
+        public static FieldInfo GetFieldInfo(this SerializedProperty property, out Type propertyType)
         {
             return GetFieldInfoFromProperty(property, out propertyType);
         }
 
-        internal static FieldInfo GetFieldInfo(this SerializedProperty property, out Type propertyType, Object target)
+        public static FieldInfo GetFieldInfo(this SerializedProperty property, out Type propertyType, Object target)
         {
             return GetFieldInfoFromProperty(property, out propertyType, target.GetType());
         }

--- a/Assets/Editor Toolbox/README.md
+++ b/Assets/Editor Toolbox/README.md
@@ -415,6 +415,11 @@ public Material var1;
 ```
 ![inspector](https://github.com/arimger/Unity-Editor-Toolbox/blob/develop/Docs/inlined1.png)
 
+```csharp
+[InLineEditor(HideScript = false)]
+public MyCustomType var1;
+```
+
 ##### Reorderable List
 
 Custom implementation of standard ReorderableList (UnityEditorInternal). Usable as an attribute in serialized fields or a single object in custom Editors.
@@ -540,9 +545,11 @@ public int var1;
 You can draw properties marked with the **[SerializeReference]** attribute with an additional type picker that allows you to manipulate what managed type will be serialized.
 
 ```csharp
-[SerializeReference, ReferencePicker]
+[SerializeReference, ReferencePicker(TypeGrouping = TypeGrouping.ByFlatName)]
 public Interface1 var1;
 [SerializeReference, ReferencePicker]
+public Interface1 var1;
+[SerializeReference, ReferencePicker(ParentType = typeof(ClassWithInterface2)]
 public ClassWithInterfaceBase var2;
 
 public interface Interface1 { }

--- a/Assets/Editor Toolbox/Runtime/Attributes/Regular/TypeConstraintAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Regular/TypeConstraintAttribute.cs
@@ -134,6 +134,10 @@ namespace UnityEngine
         /// grouping method must only be used for <see cref="MonoBehaviour"/> types.
         /// </summary>
         ByAddComponentMenu,
+        /// <summary>
+        /// Only name of the <see cref="Type"/>.
+        /// </summary>
+        ByFlatName
     }
 
     /// <summary>

--- a/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/InLineEditorAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/InLineEditorAttribute.cs
@@ -34,6 +34,12 @@ namespace UnityEngine
         public bool DrawSettings { get; private set; }
 
         /// <summary>
+        /// Indicates if the "m_Script" property should be hidden.
+        /// Will work only for Toolbox-based Editors.
+        /// </summary>
+        public bool HideScript { get; set; } = true;
+
+        /// <summary>
         /// Indicates if the inlined Editor should be disabled.
         /// </summary>
         public bool DisableEditor { get; set; }

--- a/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/ReferencePickerAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/ReferencePickerAttribute.cs
@@ -12,6 +12,16 @@ namespace UnityEngine
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
     [Conditional("UNITY_EDITOR")]
     public class ReferencePickerAttribute : ToolboxSelfPropertyAttribute
-    { }
+    {
+        public ReferencePickerAttribute()
+        { }
+
+        public ReferencePickerAttribute(Type parentType)
+        {
+            ParentType = parentType;
+        }
+
+        public Type ParentType { get; set; }
+    }
 }
 #endif

--- a/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/ReferencePickerAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/ReferencePickerAttribute.cs
@@ -16,12 +16,21 @@ namespace UnityEngine
         public ReferencePickerAttribute()
         { }
 
-        public ReferencePickerAttribute(Type parentType)
+        public ReferencePickerAttribute(Type parentType) : this(parentType, TypeGrouping.None)
+        { }
+
+        public ReferencePickerAttribute(Type parentType, TypeGrouping typeGrouping)
         {
             ParentType = parentType;
+            TypeGrouping = typeGrouping;
         }
 
         public Type ParentType { get; set; }
+        /// <summary>
+        /// Gets or sets grouping of selectable classes.
+        /// Defaults to <see cref="TypeGrouping.None"/> unless explicitly specified.
+        /// </summary>
+        public TypeGrouping TypeGrouping { get; set; } = TypeGrouping.None;
     }
 }
 #endif

--- a/Assets/Editor Toolbox/package.json
+++ b/Assets/Editor Toolbox/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "com.arimger.editor-toolbox",
+  "name": "com.browar.editor-toolbox",
   "displayName": "Editor Toolbox",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "unity": "2018.1",
   "description": "Tools, custom attributes, drawers, hierarchy overlay, and other extensions for the Unity Editor.",
   "keywords": [
@@ -16,7 +16,7 @@
 	"com.unity.editorcoroutines": "1.0.0"
   },
   "author": {
-    "name": "Arimger",
+    "name": "BroWar Collective",
     "email": "milosz.matkowski96@gmail.com",
     "url": "https://github.com/arimger"
   }

--- a/Assets/Examples/Scenes/SampleScene.unity
+++ b/Assets/Examples/Scenes/SampleScene.unity
@@ -974,6 +974,8 @@ MonoBehaviour:
     typeReference: 
   type4:
     typeReference: UnityEngine.BoxCollider, UnityEngine.PhysicsModule
+  type5:
+    typeReference: UnityEngine.TerrainCollider, UnityEngine.TerrainPhysicsModule
   scene1:
     sceneReference: {fileID: 102900000, guid: f11034f4657f51a47aac14f26410c500, type: 3}
     sceneName: SampleScene

--- a/Assets/Examples/Scenes/SampleScene.unity
+++ b/Assets/Examples/Scenes/SampleScene.unity
@@ -581,6 +581,8 @@ MonoBehaviour:
     id: 0
   var2:
     id: 1
+  var3:
+    id: 2
   references:
     version: 1
     00000000:
@@ -588,13 +590,17 @@ MonoBehaviour:
       data:
         go: {fileID: 977748987}
         var1:
-          id: 2
+          id: 3
     00000001:
+      type: {class: SampleBehaviour6/ClassWithInterface3, ns: , asm: Assembly-CSharp}
+      data:
+        var1: 31
+    00000002:
       type: {class: SampleBehaviour6/ClassWithInterface2, ns: , asm: Assembly-CSharp}
       data:
         var1: 0
         mat: {fileID: 2100000, guid: 7404c70251f9d0045a4aabaa49d83963, type: 2}
-    00000002:
+    00000003:
       type: {class: SampleBehaviour6/Struct, ns: , asm: Assembly-CSharp}
       data:
         var1: 1

--- a/Assets/Examples/Scripts/SampleBehaviour2.cs
+++ b/Assets/Examples/Scripts/SampleBehaviour2.cs
@@ -38,7 +38,7 @@ public class SampleBehaviour2 : MonoBehaviour
     [InLineEditor(drawSettings: true)]
     public AudioClip var24;
 
-    [InLineEditor]
+    [InLineEditor(HideScript = true)]
     public Mesh var25;
 
     [Label("Nested Properties", skinStyle: SkinStyle.Box)]

--- a/Assets/Examples/Scripts/SampleBehaviour5.cs
+++ b/Assets/Examples/Scripts/SampleBehaviour5.cs
@@ -15,6 +15,8 @@ public class SampleBehaviour5 : MonoBehaviour
     public SerializedType type3;
     [TypeConstraint(typeof(Collider), AllowAbstract = false, AllowObsolete = false, TypeSettings = TypeSettings.Class, TypeGrouping = TypeGrouping.None)]
     public SerializedType type4;
+    [TypeConstraint(typeof(Collider), AllowAbstract = false, AllowObsolete = false, TypeSettings = TypeSettings.Class, TypeGrouping = TypeGrouping.ByFlatName)]
+    public SerializedType type5;
 
     [Label("Serialized Scene", skinStyle: SkinStyle.Box)]
 

--- a/Assets/Examples/Scripts/SampleBehaviour6.cs
+++ b/Assets/Examples/Scripts/SampleBehaviour6.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public class SampleBehaviour6 : MonoBehaviour
 {
 #if UNITY_2019_3_OR_NEWER
-    [SerializeReference, ReferencePicker]
+    [SerializeReference, ReferencePicker(TypeGrouping = TypeGrouping.ByFlatName)]
     public Interface1 var1;
     [SerializeReference, ReferencePicker]
     public ClassWithInterfaceBase var2;

--- a/Assets/Examples/Scripts/SampleBehaviour6.cs
+++ b/Assets/Examples/Scripts/SampleBehaviour6.cs
@@ -11,6 +11,8 @@ public class SampleBehaviour6 : MonoBehaviour
     public Interface1 var1;
     [SerializeReference, ReferencePicker]
     public ClassWithInterfaceBase var2;
+    [SerializeReference, ReferencePicker(ParentType = typeof(ClassWithInterface2))]
+    public ClassWithInterfaceBase var3;
 #endif
 
     public interface Interface1 { }
@@ -48,5 +50,11 @@ public class SampleBehaviour6 : MonoBehaviour
     public class ClassWithInterface3 : ClassWithInterfaceBase
     {
         public int var1;
+    }
+
+    [Serializable]
+    public class ClassWithInterface4 : ClassWithInterface2
+    {
+        public int var33;
     }
 }

--- a/README.md
+++ b/README.md
@@ -415,6 +415,11 @@ public Material var1;
 ```
 ![inspector](https://github.com/arimger/Unity-Editor-Toolbox/blob/develop/Docs/inlined1.png)
 
+```csharp
+[InLineEditor(HideScript = false)]
+public MyCustomType var1;
+```
+
 ##### Reorderable List
 
 Custom implementation of standard ReorderableList (UnityEditorInternal). Usable as an attribute in serialized fields or a single object in custom Editors.
@@ -540,9 +545,11 @@ public int var1;
 You can draw properties marked with the **[SerializeReference]** attribute with an additional type picker that allows you to manipulate what managed type will be serialized.
 
 ```csharp
-[SerializeReference, ReferencePicker]
+[SerializeReference, ReferencePicker(TypeGrouping = TypeGrouping.ByFlatName)]
 public Interface1 var1;
 [SerializeReference, ReferencePicker]
+public Interface1 var1;
+[SerializeReference, ReferencePicker(ParentType = typeof(ClassWithInterface2)]
 public ClassWithInterfaceBase var2;
 
 public interface Interface1 { }


### PR DESCRIPTION
### Added:
- Possibility to hide the m_Script property while using the InLineEditorAttribute (HideScript = true)
- Possibility to pick base type in the ReferencePickerAttribute
- Possibility to pick display options in the ReferencePickerAttribute

### Changed:
- Fix displaying custom labels in the ToolboxEditorList
- For now all methods placed in the PropertyUtility script are public