### PR TITLE
Update SceneSerializationUtility.cs

### DIFF
--- a/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
+++ b/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
@@ -44,8 +44,10 @@ namespace Toolbox.Serialization
             foreach (var scene in EditorBuildSettings.scenes)
             {
                 if (string.IsNullOrEmpty(scene.path))
+                {
                     continue;
-
+                }
+                
                 buildIndex++;
 
                 var sceneIndex = scene.enabled ? buildIndex : InvalidSceneIndex;

--- a/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
+++ b/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
@@ -44,6 +44,10 @@ namespace Toolbox.Serialization
             foreach (var scene in EditorBuildSettings.scenes)
             {
                 buildIndex++;
+
+                if (string.IsNullOrEmpty(scene.path))
+                    continue;
+
                 var sceneIndex = scene.enabled ? buildIndex : InvalidSceneIndex;
                 var sceneAsset = EditorGUIUtility.Load(scene.path) as SceneAsset;
                 if (sceneAsset != null)

--- a/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
+++ b/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
@@ -43,10 +43,10 @@ namespace Toolbox.Serialization
             var buildIndex = -1;
             foreach (var scene in EditorBuildSettings.scenes)
             {
-                buildIndex++;
-
                 if (string.IsNullOrEmpty(scene.path))
                     continue;
+
+                buildIndex++;
 
                 var sceneIndex = scene.enabled ? buildIndex : InvalidSceneIndex;
                 var sceneAsset = EditorGUIUtility.Load(scene.path) as SceneAsset;


### PR DESCRIPTION
ref #74 

Checking if the ```scene.path``` is null or empty before Letting ```EditorGUIUtility``` load a non-existing scene to prevent an error that is hard to trace back.

closes #74 