### PR TITLE
Add label width attribute to change fields label width.

### DIFF
--- a/Assets/Editor Toolbox/Editor/Drawers/Regular/LabelWidthAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Regular/LabelWidthAttributeDrawer.cs
@@ -1,0 +1,19 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Toolbox.Editor.Drawers
+{
+    [CustomPropertyDrawer(typeof(LabelWidthAttribute))]
+    public class LabelWidthAttributeDrawer : PropertyDrawerBase
+    {
+        protected override void OnGUISafe(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var previousWidth = EditorGUIUtility.labelWidth;
+            EditorGUIUtility.labelWidth = Attribute.Width;
+            EditorGUI.PropertyField(position, property, label, property.isExpanded);
+            EditorGUIUtility.labelWidth = previousWidth;
+        }
+
+        private LabelWidthAttribute Attribute => attribute as LabelWidthAttribute;
+    }
+}

--- a/Assets/Editor Toolbox/Editor/Drawers/Regular/LabelWidthAttributeDrawer.cs.meta
+++ b/Assets/Editor Toolbox/Editor/Drawers/Regular/LabelWidthAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1536da1dfd9ae6841b99ecd14495488d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor Toolbox/Runtime/Attributes/Regular/LabelWidthAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Regular/LabelWidthAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace UnityEngine
+{
+    /// <summary>
+    /// Change field label width.
+    /// <para>Label width</para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    [Conditional("UNITY_EDITOR")]
+    public class LabelWidthAttribute : PropertyAttribute
+    {
+        public LabelWidthAttribute(float width = 120)
+        {
+            Width = width;
+        }
+
+        public float Width { get; private set; }
+    }
+}

--- a/Assets/Editor Toolbox/Runtime/Attributes/Regular/LabelWidthAttribute.cs.meta
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Regular/LabelWidthAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59d1b17ab0a67ba449045cb5c6afede2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This attribute prevent long label to be clamped. It makes the label more readable.
![image](https://github.com/arimger/Unity-Editor-Toolbox/assets/17614861/4dac019f-109d-4829-888c-dcdd1d026e88)
![image](https://github.com/arimger/Unity-Editor-Toolbox/assets/17614861/a6690819-d9e9-4424-a50a-938e3bbdc0e4)
