### PR TITLE
Fixed Scene View selection not working with some prefabs

### DIFF
--- a/Assets/Editor Toolbox/Editor/ToolboxEditorSceneView.cs
+++ b/Assets/Editor Toolbox/Editor/ToolboxEditorSceneView.cs
@@ -25,7 +25,7 @@ namespace Toolbox.Editor
             {
                 hitObjectsArray = hitObjects.ToArray();
 
-                var go = HandleUtility.PickGameObject(mousePosition, true, hitObjectsArray);
+                var go = HandleUtility.PickGameObject(mousePosition, false, hitObjectsArray);
                 if (go == null)
                 {
                     break;


### PR DESCRIPTION
Attempting to use the scene view selector on nested prefabs would cause it to loop until reaching max iterations.