### PR TITLE
Develop - 0.12.4

### DIFF
--- a/Assets/Editor Toolbox/CHANGELOG.md
+++ b/Assets/Editor Toolbox/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.4 [31.07.2023]
+
+### Changed:
+- Fix SceneView selection tool behaviour when selecting nested prefabs
+- Fix InvalidOperationException when ExitGUIException is thrown inside PropertyScope
+- Minor SerializedScene index calculation performance improvements
+- Fix SearchablePopup styles initialization in Unity 2022+
+- Minor visual improvements on how ReferencePicker label is rendered 
+
 ## 0.12.3 [17.06.2023]
 
 ### Changed:

--- a/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
@@ -80,12 +80,16 @@ namespace Toolbox.Editor.Drawers
             property.serializedObject.ApplyModifiedProperties();
         }
 
-        private Rect PrepareTypePropertyPosition(in Rect labelPosition, in Rect inputPosition, bool isPropertyExpanded)
+        private Rect PrepareTypePropertyPosition(bool hasLabel, in Rect labelPosition, in Rect inputPosition, bool isPropertyExpanded)
         {
             var position = new Rect(inputPosition);
-            var baseLabelWidth = EditorGUIUtility.labelWidth + labelWidthOffset;
-            var realLabelWidth = labelPosition.width;
-            var labelWidth = Mathf.Max(baseLabelWidth, realLabelWidth);
+            if (!hasLabel)
+            {
+                position.xMin += EditorGUIUtility.standardVerticalSpacing;
+                return position;
+            }
+
+            //skip row only if label exists
             if (isPropertyExpanded)
             {
                 //property is expanded and we have place to move it to the next row
@@ -94,8 +98,10 @@ namespace Toolbox.Editor.Drawers
                 return position;
             }
 
+            var baseLabelWidth = EditorGUIUtility.labelWidth + labelWidthOffset;
+            var realLabelWidth = labelPosition.width;
             //adjust position to already rendered label
-            position.xMin += labelWidth;
+            position.xMin += Mathf.Max(baseLabelWidth, realLabelWidth);
             return position;
         }
 
@@ -111,7 +117,9 @@ namespace Toolbox.Editor.Drawers
                 EditorGUI.indentLevel++;
                 var labelRect = propertyScope.LabelRect;
                 var inputRect = propertyScope.InputRect;
-                var position = PrepareTypePropertyPosition(in labelRect, in inputRect, isPropertyExpanded);
+
+                var hasLabel = !string.IsNullOrEmpty(label.text);
+                var position = PrepareTypePropertyPosition(hasLabel, in labelRect, in inputRect, isPropertyExpanded);
 
                 var parentType = GetParentType(property, attribute);
                 CreateTypeProperty(position, property, parentType);

--- a/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
@@ -102,7 +102,8 @@ namespace Toolbox.Editor.Drawers
 
         protected override void OnGuiSafe(SerializedProperty property, GUIContent label, ReferencePickerAttribute attribute)
         {
-            using (var propertyScope = new PropertyScope(property, label))
+            //NOTE: we want to close scope manually because ExitGUIException can interrupt drawing and SerializedProperties stack
+            using (var propertyScope = new PropertyScope(property, label, closeManually: true))
             {
                 UpdateContexts(attribute);
 
@@ -120,6 +121,7 @@ namespace Toolbox.Editor.Drawers
                 }
 
                 EditorGUI.indentLevel--;
+                propertyScope.Close();
             }
         }
 

--- a/Assets/Editor Toolbox/Editor/Internal/PropertyScope.cs
+++ b/Assets/Editor Toolbox/Editor/Internal/PropertyScope.cs
@@ -12,11 +12,18 @@ namespace Toolbox.Editor.Internal
     internal class PropertyScope : IDisposable
     {
         private readonly SerializedProperty property;
+        private readonly bool closeManually;
+        private bool isClosed;
 
+        public PropertyScope(SerializedProperty property, GUIContent label) : this(property, label, false)
+        { }
 
-        public PropertyScope(SerializedProperty property, GUIContent label)
+        public PropertyScope(SerializedProperty property, GUIContent label, bool closeManually)
         {
             this.property = property;
+            this.closeManually = closeManually;
+            isClosed = false;
+
             ToolboxEditorGui.BeginProperty(property, ref label, out var rect);
             HandleEvents(rect);
             TryDrawLabel(rect, label);
@@ -50,9 +57,20 @@ namespace Toolbox.Editor.Internal
         }
 
 
-        public void Dispose()
+        public void Close()
         {
             ToolboxEditorGui.CloseProperty();
+            isClosed = true;
+        }
+
+        public void Dispose()
+        {
+            if (closeManually || isClosed)
+            {
+                return;
+            }
+
+            Close();
         }
 
 

--- a/Assets/Editor Toolbox/Editor/Internal/SearchablePopup.cs
+++ b/Assets/Editor Toolbox/Editor/Internal/SearchablePopup.cs
@@ -316,9 +316,15 @@ namespace Toolbox.Editor.Internal
                 toolbarStyle = new GUIStyle(EditorStyles.toolbar);
                 scrollbarStyle = new GUIStyle(GUI.skin.verticalScrollbar);
                 selectionStyle = new GUIStyle("SelectionRect");
+#if UNITY_2022_1_OR_NEWER
+                searchBoxStyle = new GUIStyle("ToolbarSearchTextField");
+                showCancelButtonStyle = new GUIStyle("ToolbarSearchCancelButton");
+                hideCancelButtonStyle = new GUIStyle("ToolbarSearchCancelButtonEmpty");
+#else
                 searchBoxStyle = new GUIStyle("ToolbarSeachTextField");
                 showCancelButtonStyle = new GUIStyle("ToolbarSeachCancelButton");
                 hideCancelButtonStyle = new GUIStyle("ToolbarSeachCancelButtonEmpty");
+#endif
             }
         }
     }

--- a/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
+++ b/Assets/Editor Toolbox/Runtime/Serialization/SceneSerializationUtility.cs
@@ -3,6 +3,7 @@
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
+using UnityEngine.SceneManagement;
 
 namespace Toolbox.Serialization
 {
@@ -40,25 +41,18 @@ namespace Toolbox.Serialization
         internal static void RefreshCache()
         {
             cachedScenes.Clear();
-            var buildIndex = -1;
             foreach (var scene in EditorBuildSettings.scenes)
             {
-                if (string.IsNullOrEmpty(scene.path))
+                var path = scene.path;
+                if (string.IsNullOrEmpty(path))
                 {
                     continue;
                 }
 
-                var sceneAsset = EditorGUIUtility.Load(scene.path) as SceneAsset;
+                var sceneAsset = EditorGUIUtility.Load(path) as SceneAsset;
                 if (sceneAsset == null)
                 {
                     continue;
-                }
-
-                var sceneIndex = InvalidSceneIndex;
-                if (scene.enabled)
-                {
-                    buildIndex++;
-                    sceneIndex = buildIndex;
                 }
 
                 if (cachedScenes.ContainsKey(sceneAsset))
@@ -68,9 +62,9 @@ namespace Toolbox.Serialization
 
                 cachedScenes.Add(sceneAsset, new SceneData()
                 {
-                    BuildIndex = sceneIndex,
+                    BuildIndex = SceneUtility.GetBuildIndexByScenePath(path),
                     SceneName = sceneAsset.name,
-                    ScenePath = scene.path
+                    ScenePath = path
                 });
             }
         }

--- a/Assets/Editor Toolbox/package.json
+++ b/Assets/Editor Toolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.browar.editor-toolbox",
   "displayName": "Editor Toolbox",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "unity": "2018.1",
   "description": "Tools, custom attributes, drawers, hierarchy overlay, and other extensions for the Unity Editor.",
   "keywords": [


### PR DESCRIPTION
### Changed:
- Fix SceneView selection tool behaviour when selecting nested prefabs
- Fix InvalidOperationException when ExitGUIException is thrown inside PropertyScope
- Minor SerializedScene index calculation performance improvements
- Fix SearchablePopup styles initialization in Unity 2022+
- Minor visual improvements on how ReferencePicker label is rendered 