### PR TITLE
Develop - 0.12.8

### DIFF
--- a/Assets/Editor Toolbox/Editor/ToolboxDrawerModule.cs
+++ b/Assets/Editor Toolbox/Editor/ToolboxDrawerModule.cs
@@ -261,7 +261,11 @@ namespace Toolbox.Editor
         /// </summary>
         internal static bool HasNativeTypeDrawer(Type type)
         {
+#if UNITY_2023_3_OR_NEWER
+            var parameters = new object[] { type, null, false };
+#else
             var parameters = new object[] { type };
+#endif
             var result = getDrawerTypeForTypeMethod.Invoke(null, parameters) as Type;
             return result != null && typeof(PropertyDrawer).IsAssignableFrom(result);
         }

--- a/Assets/Editor Toolbox/Editor/Utilities/ScriptingUtility.cs
+++ b/Assets/Editor Toolbox/Editor/Utilities/ScriptingUtility.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using UnityEditor;
+using UnityEditor.Build;
 
 namespace Toolbox.Editor
 {
@@ -9,14 +10,24 @@ namespace Toolbox.Editor
     {
         public static List<string> GetDefines()
         {
+#if UNITY_2023_1_OR_NEWER
+            var target = NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            var defines = PlayerSettings.GetScriptingDefineSymbols(target);
+#else
             var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+#endif
             return defines.Split(';').ToList();
         }
 
         public static void SetDefines(List<string> definesList)
         {
             var defines = string.Join(";", definesList.ToArray());
+#if UNITY_2023_1_OR_NEWER
+            var target = NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            PlayerSettings.SetScriptingDefineSymbols(target, defines);
+#else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#endif
         }
 
         public static void AppendDefine(string define)


### PR DESCRIPTION
### Changed:
- Fix calling the ScriptAttributeUtility.GetDrawerTypeForType method in Unity 2033.3+
- Fix getting and setting scripting defines in Unity 2023+