### PR TITLE
Develop - 0.12.9

### DIFF
--- a/Assets/Editor Toolbox/CHANGELOG.md
+++ b/Assets/Editor Toolbox/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.12.9 [27.01.2024]
+
+### Changed:
+- Fix rare invalid SerializedProperty iterator when editing child properties
+- Extend objects creation behaviour while using the ReferencePickerAttribute (possibility to create uninitialized objects)
+- Minor UX improvements in the ScriptableObjectCreationWizard
+
 ## 0.12.8 [29.12.2023]
 
 ### Changed:

--- a/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
@@ -1,5 +1,6 @@
 ﻿#if UNITY_2019_3_OR_NEWER
 using System;
+using System.Runtime.Serialization;
 
 using UnityEditor;
 using UnityEngine;
@@ -74,7 +75,7 @@ namespace Toolbox.Editor.Drawers
 
         private void UpdateTypeProperty(SerializedProperty property, Type referenceType)
         {
-            var obj = referenceType != null ? Activator.CreateInstance(referenceType) : null;
+            var obj = referenceType != null ? FormatterServices.GetUninitializedObject(referenceType) : null;
             property.serializedObject.Update();
             property.managedReferenceValue = obj;
             property.serializedObject.ApplyModifiedProperties();

--- a/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Toolbox/PropertySelf/ReferencePickerAttributeDrawer.cs
@@ -1,6 +1,5 @@
 ﻿#if UNITY_2019_3_OR_NEWER
 using System;
-using System.Runtime.Serialization;
 
 using UnityEditor;
 using UnityEngine;
@@ -17,13 +16,12 @@ namespace Toolbox.Editor.Drawers
         private static readonly TypeAppearanceContext sharedAppearance = new TypeAppearanceContext(sharedConstraint, TypeGrouping.None, true);
         private static readonly TypeField typeField = new TypeField(sharedConstraint, sharedAppearance);
 
-
         private void UpdateContexts(ReferencePickerAttribute attribute)
         {
             sharedAppearance.TypeGrouping = attribute.TypeGrouping;
         }
 
-        private Type GetParentType(SerializedProperty property, ReferencePickerAttribute attribute)
+        private Type GetParentType(ReferencePickerAttribute attribute, SerializedProperty property)
         {
             var fieldInfo = property.GetFieldInfo(out _);
             var fieldType = property.GetProperType(fieldInfo);
@@ -42,7 +40,7 @@ namespace Toolbox.Editor.Drawers
             return fieldType;
         }
 
-        private void CreateTypeProperty(Rect position, SerializedProperty property, Type parentType)
+        private void CreateTypeProperty(SerializedProperty property, Type parentType, ReferencePickerAttribute attribute, Rect position)
         {
             TypeUtilities.TryGetTypeFromManagedReferenceFullTypeName(property.managedReferenceFullTypename, out var currentType);
             typeField.OnGui(position, true, (type) =>
@@ -51,7 +49,7 @@ namespace Toolbox.Editor.Drawers
                 {
                     if (!property.serializedObject.isEditingMultipleObjects)
                     {
-                        UpdateTypeProperty(property, type);
+                        UpdateTypeProperty(property, type, attribute);
                     }
                     else
                     {
@@ -61,7 +59,7 @@ namespace Toolbox.Editor.Drawers
                             using (var so = new SerializedObject(target))
                             {
                                 SerializedProperty sp = so.FindProperty(property.propertyPath);
-                                UpdateTypeProperty(sp, type);
+                                UpdateTypeProperty(sp, type, attribute);
                             }
                         }
                     }
@@ -73,9 +71,10 @@ namespace Toolbox.Editor.Drawers
             }, currentType, parentType);
         }
 
-        private void UpdateTypeProperty(SerializedProperty property, Type referenceType)
+        private void UpdateTypeProperty(SerializedProperty property, Type targetType, ReferencePickerAttribute attribute)
         {
-            var obj = referenceType != null ? FormatterServices.GetUninitializedObject(referenceType) : null;
+            var forceUninitializedInstance = attribute.ForceUninitializedInstance;
+            var obj = ReflectionUtility.CreateInstance(targetType, forceUninitializedInstance);
             property.serializedObject.Update();
             property.managedReferenceValue = obj;
             property.serializedObject.ApplyModifiedProperties();
@@ -106,7 +105,6 @@ namespace Toolbox.Editor.Drawers
             return position;
         }
 
-
         protected override void OnGuiSafe(SerializedProperty property, GUIContent label, ReferencePickerAttribute attribute)
         {
             //NOTE: we want to close scope manually because ExitGUIException can interrupt drawing and SerializedProperties stack
@@ -122,8 +120,8 @@ namespace Toolbox.Editor.Drawers
                 var hasLabel = !string.IsNullOrEmpty(label.text);
                 var position = PrepareTypePropertyPosition(hasLabel, in labelRect, in inputRect, isPropertyExpanded);
 
-                var parentType = GetParentType(property, attribute);
-                CreateTypeProperty(position, property, parentType);
+                var parentType = GetParentType(attribute, property);
+                CreateTypeProperty(property, parentType, attribute, position);
                 if (isPropertyExpanded)
                 {
                     ToolboxEditorGui.DrawPropertyChildren(property);
@@ -133,7 +131,6 @@ namespace Toolbox.Editor.Drawers
                 propertyScope.Close();
             }
         }
-
 
         public override bool IsPropertyValid(SerializedProperty property)
         {

--- a/Assets/Editor Toolbox/Editor/ToolboxEditorGui.cs
+++ b/Assets/Editor Toolbox/Editor/ToolboxEditorGui.cs
@@ -531,7 +531,12 @@ namespace Toolbox.Editor
                 enterChildren = false;
                 var childProperty = targetProperty.Copy();
                 //handle current property using Toolbox features
+                EditorGUI.BeginChangeCheck();
                 drawElementAction(childProperty);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    break;
+                }
             }
         }
 

--- a/Assets/Editor Toolbox/Editor/Utilities/ReflectionUtility.cs
+++ b/Assets/Editor Toolbox/Editor/Utilities/ReflectionUtility.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Reflection;
-
+using System.Runtime.Serialization;
 using UnityEditor;
 using Object = UnityEngine.Object;
 
@@ -8,11 +8,10 @@ namespace Toolbox.Editor
 {
     internal static class ReflectionUtility
     {
-        private readonly static Assembly editorAssembly = typeof(UnityEditor.Editor).Assembly;
+        private static readonly Assembly editorAssembly = typeof(UnityEditor.Editor).Assembly;
 
         public const BindingFlags allBindings = BindingFlags.Instance |
             BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public;
-
 
         /// <summary>
         /// Returns <see cref="MethodInfo"/> of the searched method within the Editor <see cref="Assembly"/>.
@@ -95,6 +94,32 @@ namespace Toolbox.Editor
             }
 
             return true;
+        }
+
+        internal static object CreateInstance(Type targetType, bool forceUninitializedInstance)
+        {
+            if (targetType == null)
+            {
+                return null;
+            }
+
+            if (forceUninitializedInstance)
+            {
+                return FormatterServices.GetUninitializedObject(targetType);
+            }
+
+            if (targetType.IsValueType)
+            {
+                return Activator.CreateInstance(targetType);
+            }
+
+            var defaultConstructor = targetType.GetConstructor(Type.EmptyTypes);
+            if (defaultConstructor != null)
+            {
+                return Activator.CreateInstance(targetType);
+            }
+
+            return FormatterServices.GetUninitializedObject(targetType);
         }
     }
 }

--- a/Assets/Editor Toolbox/Editor/Wizards/ToolboxWizard.cs
+++ b/Assets/Editor Toolbox/Editor/Wizards/ToolboxWizard.cs
@@ -11,7 +11,7 @@ namespace Toolbox.Editor.Wizards
 
         private Vector2 scrollPosition;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             if (targetEditor != null)
             {
@@ -19,7 +19,7 @@ namespace Toolbox.Editor.Wizards
             }
         }
 
-        private void OnDestroy()
+        protected virtual void OnDestroy()
         {
             DestroyImmediate(targetEditor);
         }

--- a/Assets/Editor Toolbox/README.md
+++ b/Assets/Editor Toolbox/README.md
@@ -631,13 +631,20 @@ public int var1;
 #### SerializeReference (ReferencePicker) <a name="toolboxreference"></a>
 
 You can draw properties marked with the **[SerializeReference]** attribute with an additional type picker that allows you to manipulate what managed type will be serialized.
-
+Depending on the picked type we have different object creation strategies:
+- `Activator.CreateInstance(targetType)` (default constructor will be called and all readonly members will be initialized)
+	- Target type has default constructor
+	- Target type is a value type
+- `FormatterServices.GetUninitializedObject(targetType)` (object will be uninitialized)
+	- Target type has one or more constructors with arguments
+	- `ForceUninitializedInstance` property is set to true
+	
 To prevent issues after renaming types use `UnityEngine.Scripting.APIUpdating.MovedFromAttribute`.
 
 ```csharp
 [SerializeReference, ReferencePicker(TypeGrouping = TypeGrouping.ByFlatName)]
 public Interface1 var1;
-[SerializeReference, ReferencePicker]
+[SerializeReference, ReferencePicker(ForceUninitializedInstance = true)]
 public Interface1 var1;
 [SerializeReference, ReferencePicker(ParentType = typeof(ClassWithInterface2)]
 public ClassWithInterfaceBase var2;

--- a/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/ReferencePickerAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Toolbox/PropertySelfAttributes/ReferencePickerAttribute.cs
@@ -31,6 +31,8 @@ namespace UnityEngine
         /// Defaults to <see cref="TypeGrouping.None"/> unless explicitly specified.
         /// </summary>
         public TypeGrouping TypeGrouping { get; set; } = TypeGrouping.None;
+
+        public bool ForceUninitializedInstance { get; set; }
     }
 }
 #endif

--- a/Assets/Editor Toolbox/package.json
+++ b/Assets/Editor Toolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.browar.editor-toolbox",
   "displayName": "Editor Toolbox",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "unity": "2018.1",
   "description": "Tools, custom attributes, drawers, hierarchy overlay, and other extensions for the Unity Editor.",
   "keywords": [

--- a/Assets/Examples/Scripts/SampleBehaviour6.cs
+++ b/Assets/Examples/Scripts/SampleBehaviour6.cs
@@ -9,7 +9,7 @@ public class SampleBehaviour6 : MonoBehaviour
 #if UNITY_2019_3_OR_NEWER
     [SerializeReference, ReferencePicker(TypeGrouping = TypeGrouping.ByFlatName)]
     public Interface1 var1;
-    [SerializeReference, ReferencePicker]
+    [SerializeReference, ReferencePicker(ForceUninitializedInstance = true)]
     public ClassWithInterfaceBase var2;
     [SerializeReference, ReferencePicker(ParentType = typeof(ClassWithInterface2))]
     public ClassWithInterfaceBase var3;
@@ -25,6 +25,12 @@ public class SampleBehaviour6 : MonoBehaviour
     {
         public bool var1;
         public bool var2;
+
+        public Struct(bool var1, bool var2)
+        {
+            this.var1 = var1;
+            this.var2 = var2;
+        }
     }
 
     public abstract class ClassWithInterfaceBase : Interface1
@@ -54,6 +60,11 @@ public class SampleBehaviour6 : MonoBehaviour
     public class ClassWithInterface3 : ClassWithInterfaceBase
     {
         public int var1;
+
+        public ClassWithInterface3(int var1)
+        {
+            this.var1 = var1;
+        }
     }
 
     [Serializable]

--- a/README.md
+++ b/README.md
@@ -631,13 +631,20 @@ public int var1;
 #### SerializeReference (ReferencePicker) <a name="toolboxreference"></a>
 
 You can draw properties marked with the **[SerializeReference]** attribute with an additional type picker that allows you to manipulate what managed type will be serialized.
-
+Depending on the picked type we have different object creation strategies:
+- `Activator.CreateInstance(targetType)` (default constructor will be called and all readonly members will be initialized)
+	- Target type has default constructor
+	- Target type is a value type
+- `FormatterServices.GetUninitializedObject(targetType)` (object will be uninitialized)
+	- Target type has one or more constructors with arguments
+	- `ForceUninitializedInstance` property is set to true
+	
 To prevent issues after renaming types use `UnityEngine.Scripting.APIUpdating.MovedFromAttribute`.
 
 ```csharp
 [SerializeReference, ReferencePicker(TypeGrouping = TypeGrouping.ByFlatName)]
 public Interface1 var1;
-[SerializeReference, ReferencePicker]
+[SerializeReference, ReferencePicker(ForceUninitializedInstance = true)]
 public Interface1 var1;
 [SerializeReference, ReferencePicker(ParentType = typeof(ClassWithInterface2)]
 public ClassWithInterfaceBase var2;


### PR DESCRIPTION
### Changed:
- Fix rare invalid SerializedProperty iterator when editing child properties
- Extend objects creation behaviour while using the ReferencePickerAttribute (possibility to create uninitialized objects)
- Minor UX improvements in the ScriptableObjectCreationWizard