### PR TITLE
Develop - 0.13.1

### DIFF
--- a/Assets/Editor Toolbox/CHANGELOG.md
+++ b/Assets/Editor Toolbox/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.1 [30.08.2024]
+
+### Changed:
+- Fix runtime compilation error caused by the SerializedDirectory
+
 ## 0.13.0 [28.08.2024]
 
 ### Added:

--- a/Assets/Editor Toolbox/Runtime/Serialization/SerializedDirectory.cs
+++ b/Assets/Editor Toolbox/Runtime/Serialization/SerializedDirectory.cs
@@ -16,6 +16,7 @@ namespace UnityEngine
         [SerializeField, Disable]
         private string path;
 
+#if UNITY_EDITOR
         internal static bool IsAssetValid(DefaultAsset asset, out string path)
         {
             path = asset != null ? AssetDatabase.GetAssetPath(asset) : null;
@@ -33,7 +34,7 @@ namespace UnityEngine
 
             return false;
         }
-
+#endif
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         { }
 

--- a/Assets/Editor Toolbox/package.json
+++ b/Assets/Editor Toolbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.browar.editor-toolbox",
   "displayName": "Editor Toolbox",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "unity": "2018.1",
   "description": "Tools, custom attributes, drawers, hierarchy overlay, and other extensions for the Unity Editor.",
   "keywords": [


### PR DESCRIPTION
### Changed:
- Fix runtime compilation error caused by the SerializedDirectory

Related : https://github.com/arimger/Unity-Editor-Toolbox/issues/117