### PR TITLE
NotNullAttribute Message Type

### DIFF
--- a/Assets/Editor Toolbox/Editor/Drawers/Regular/NotNullAttributeDrawer.cs
+++ b/Assets/Editor Toolbox/Editor/Drawers/Regular/NotNullAttributeDrawer.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 using UnityEngine;
 
 namespace Toolbox.Editor.Drawers
@@ -30,11 +30,24 @@ namespace Toolbox.Editor.Drawers
                 var helpBoxRect = new Rect(position.x,
                                            position.y,
                                            position.width, Style.boxHeight);
-                EditorGUI.HelpBox(helpBoxRect, Attribute.Label, MessageType.Error);
+                EditorGUI.HelpBox(helpBoxRect, Attribute.Label, (MessageType)Attribute.Type);
                 position.y += Style.boxHeight + Style.spacing * 2;
 
                 //change temporary GUI background color 
-                using (new GuiBackground(Style.errorBackgroundColor))
+                Color bgColor;
+                switch (Attribute.Type)
+                {
+                    case UnityMessageType.Error:
+                        bgColor = Style.errorBackgroundColor;
+                        break;
+                    case UnityMessageType.Warning:
+                        bgColor = Style.warningBackgroundColor;
+                        break;
+                    default:
+                        bgColor = Style.infoBackgroundColor;
+                        break;
+                }
+                using (new GuiBackground(bgColor))
                 {
                     EditorGUI.PropertyField(position, property, label, property.isExpanded);
                 }
@@ -57,6 +70,8 @@ namespace Toolbox.Editor.Drawers
 #endif
             internal static readonly float spacing = EditorGUIUtility.standardVerticalSpacing;
 
+            internal static readonly Color infoBackgroundColor = Color.white;
+            internal static readonly Color warningBackgroundColor = Color.yellow;
             internal static readonly Color errorBackgroundColor = Color.red;
         }
     }

--- a/Assets/Editor Toolbox/Runtime/Attributes/Property/Regular/NotNullAttribute.cs
+++ b/Assets/Editor Toolbox/Runtime/Attributes/Property/Regular/NotNullAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace UnityEngine
@@ -12,14 +12,16 @@ namespace UnityEngine
     [Conditional("UNITY_EDITOR")]
     public class NotNullAttribute : PropertyAttribute
     {
-        public NotNullAttribute() : this("Variable has to be assigned.")
+        public NotNullAttribute(UnityMessageType type = UnityMessageType.Error) : this("Variable has to be assigned.", type)
         { }
 
-        public NotNullAttribute(string label)
+        public NotNullAttribute(string label, UnityMessageType type = UnityMessageType.Error)
         {
             Label = label;
+            Type = type;
         }
 
         public string Label { get; private set; }
+        public UnityMessageType Type { get; private set; }
     }
 }


### PR DESCRIPTION
Adds a `type` parameter to the `[NotNull]` attribute, allowing you to specify the type of message to display if the value is null.

For example, it is useful to display a warning if the field is expected to have a non-null value eventually, but the null state does not block program execution.

<img width="479" height="142" alt="image" src="https://github.com/user-attachments/assets/79835cce-c453-4377-82b6-0398f4a2cb86" />

The default value remains `Error`.